### PR TITLE
[CLOUD-570] Serialize execution of some recipes on multiple machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,29 @@ We leverage Berkshelf to transparently download and install transitive cookbook 
 ---
 Cluster definition is an expressive DSL based on YAML as you can see in the following sample. Since Karamel can run several clusters simultaneously, name of the cluster must be unique in each Karamel-runtime.
 
+#### Recipes execution parallelism
+Karamel will execute recipes in parallel on all machines respecting any dependency stated in Karamelfile. Regardless 
+of the dependencies, the same recipes will be executed in parallel on all machines. For example if we run recipe 
+`ndb::ndbd` on three machines, they may be executed in parallel depending on how Karamel will schedule them.
+
+In some cases we want to guarantee only a portion of machines to execute recipes in parallel. For example in case of 
+a rolling restart/upgrade we want to execute `ndb::ndbd` serially. You can configure recipe parallelism under 
+`runtimeConfiguration/recipesParallelism` section in the cluster definition in the format `recipe_name: parallelism`.
+Multiple recipes can be configured. For example:
+
+```yaml
+runtimeConfiguration:                                                                                                                                                                                                                         
+  recipesParallelism:                                                                                                                                                                                                                         
+    consul::master: 1                                                                                                                                                                                                                         
+    ndb::ndbd: 1                                                                                                                                                                                                                         
+    ndb::mysqld: 2 
+    ndb::mysqld_tls: 2 
+    onlinefs::default: 1 
+    hops::nn: 1                                                                                                                                                                                                                               
+    hops::rm: 1
+```
+
+#### Cloud providers
 We support five cloud providers: Amazon EC2 (ec2), Google Compute Engine (gce), Openstack Nova (nova), OCCI and bare-metal (baremetal). You can define provider globally or per group. In the group scope, you can overwrite some attributes of the network/machines in the global scope or you can entirely choose another cloud provider, that's how we support multi-cloud deployment. Settings and properties for each provider is introduced in a following separate section. 
 
  Cookbooks section introduces github references to the used cookbooks, it is also possible to refer to a specific version or branch for each github repository.

--- a/karamel-common/src/main/java/se/kth/karamel/common/clusterdef/Scope.java
+++ b/karamel-common/src/main/java/se/kth/karamel/common/clusterdef/Scope.java
@@ -5,6 +5,7 @@
  */
 package se.kth.karamel.common.clusterdef;
 
+import se.kth.karamel.common.clusterdef.yaml.RuntimeConfiguration;
 import se.kth.karamel.common.exception.ValidationException;
 
 /**
@@ -14,12 +15,14 @@ import se.kth.karamel.common.exception.ValidationException;
 public abstract class Scope {
 
   private Baremetal baremetal;
+  private RuntimeConfiguration runtimeConfiguration = new RuntimeConfiguration();
 
   public Scope() {
   }
 
   public Scope(Scope scope) {
     this.baremetal = scope.getBaremetal();
+    this.runtimeConfiguration = scope.getRuntimeConfiguration();
   }
 
   public abstract Object getAttr(String key);
@@ -40,5 +43,13 @@ public abstract class Scope {
     if (baremetal != null) {
       baremetal.validate();
     }
+  }
+
+  public RuntimeConfiguration getRuntimeConfiguration() {
+    return runtimeConfiguration;
+  }
+
+  public void setRuntimeConfiguration(RuntimeConfiguration runtimeConfiguration) {
+    this.runtimeConfiguration = runtimeConfiguration;
   }
 }

--- a/karamel-common/src/main/java/se/kth/karamel/common/clusterdef/yaml/RuntimeConfiguration.java
+++ b/karamel-common/src/main/java/se/kth/karamel/common/clusterdef/yaml/RuntimeConfiguration.java
@@ -1,0 +1,16 @@
+package se.kth.karamel.common.clusterdef.yaml;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class RuntimeConfiguration {
+  private Map<String, Integer> recipesParallelism = new HashMap<>();
+
+  public Map<String, Integer> getRecipesParallelism() {
+    return recipesParallelism;
+  }
+
+  public void setRecipesParallelism(Map<String, Integer> recipeParallelism) {
+    this.recipesParallelism = recipeParallelism;
+  }
+}

--- a/karamel-core/src/main/java/se/kth/karamel/backend/ClusterManager.java
+++ b/karamel-core/src/main/java/se/kth/karamel/backend/ClusterManager.java
@@ -323,7 +323,7 @@ public class ClusterManager implements Runnable {
             generateClusterChefJsonsForPurge(definition, runtime);
         currentDag = DagBuilder.getPurgingDag(definition, runtime, stats, machinesMonitor, chefJsons);
       }
-      currentDag.start();
+      currentDag.start(definition);
     } catch (Exception ex) {
       runtime.issueFailure(new Failure(Failure.Type.DAG_FAILURE, ex.getMessage()));
       throw ex;

--- a/karamel-core/src/main/java/se/kth/karamel/backend/dag/DagTaskCallback.java
+++ b/karamel-core/src/main/java/se/kth/karamel/backend/dag/DagTaskCallback.java
@@ -25,4 +25,6 @@ public interface DagTaskCallback {
   public void terminated();
   
   public void skipped();
+
+  Dag getDag();
 }

--- a/karamel-core/src/main/java/se/kth/karamel/backend/dag/RecipeSerialization.java
+++ b/karamel-core/src/main/java/se/kth/karamel/backend/dag/RecipeSerialization.java
@@ -1,0 +1,78 @@
+package se.kth.karamel.backend.dag;
+
+import org.apache.log4j.Logger;
+import se.kth.karamel.backend.running.model.tasks.RunRecipeTask;
+
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+public class RecipeSerialization {
+  private static final Logger logger = Logger.getLogger(RecipeSerialization.class);
+  private final Semaphore parallelism;
+  private final Integer maxParallelism;
+  private final Set<RecipeSerializationClaim> claims;
+  private final ReentrantReadWriteLock claimsLock;
+
+  public RecipeSerialization(Integer parallelism) {
+    this.parallelism = new Semaphore(parallelism, true);
+    this.maxParallelism = parallelism;
+    claims = new TreeSet<>(new Comparator<RecipeSerializationClaim>() {
+      @Override
+      public int compare(RecipeSerializationClaim t0, RecipeSerializationClaim t1) {
+        return t0.getClaimedAt().compareTo(t1.getClaimedAt());
+      }
+    });
+    claimsLock = new ReentrantReadWriteLock(true);
+  }
+
+  public void release(RunRecipeTask task) {
+    parallelism.release();
+    claimsLock.writeLock().lock();
+    try {
+      claims.remove(new RecipeSerializationClaim(task));
+    } finally {
+      claimsLock.writeLock().unlock();
+    }
+    logger.info("Released serializable execution of " + task.getRecipeCanonicalName() + " on "
+        + task.getMachineId());
+  }
+
+  public void prepareToExecute(RunRecipeTask task) throws InterruptedException {
+    logger.info("Prepare to run " + task.getRecipeCanonicalName() + " on " + task.getMachineId());
+    if (!parallelism.tryAcquire()) {
+      logger.info("Could not run " + task.getRecipeCanonicalName() + " on " + task.getMachineId()
+          + " at the moment because parallelism is limited. Available parallelism permits: "
+          + parallelism.availablePermits() + "/" + maxParallelism + " - we wait until a permit becomes available."
+          + " Current claims: " + printableClaims());
+      parallelism.acquire();
+    }
+    claimsLock.writeLock().lock();
+    try {
+      claims.add(new RecipeSerializationClaim(task));
+    } finally {
+      claimsLock.writeLock().unlock();
+    }
+    logger.info("Proceed with running " + task.getRecipeCanonicalName() + " on " + task.getMachineId());
+  }
+
+  private String printableClaims() {
+    claimsLock.readLock().lock();
+    try {
+      StringBuffer sb = new StringBuffer();
+      Iterator<RecipeSerializationClaim> i = claims.iterator();
+      int o = 0;
+      while (i.hasNext()) {
+        sb.append(String.format("[%d] ", o));
+        sb.append(i.next().getId()).append(" ");
+        o++;
+      }
+      return sb.toString();
+    } finally {
+      claimsLock.readLock().unlock();
+    }
+  }
+}

--- a/karamel-core/src/main/java/se/kth/karamel/backend/dag/RecipeSerializationClaim.java
+++ b/karamel-core/src/main/java/se/kth/karamel/backend/dag/RecipeSerializationClaim.java
@@ -1,0 +1,37 @@
+package se.kth.karamel.backend.dag;
+
+import se.kth.karamel.backend.running.model.tasks.RunRecipeTask;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public class RecipeSerializationClaim {
+  private final String id;
+  private final Instant claimedAt;
+
+  public RecipeSerializationClaim(RunRecipeTask task) {
+    id = String.format("%s@%s", task.getRecipeCanonicalName(), task.getMachineId());
+    claimedAt = Instant.now();
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public Instant getClaimedAt() {
+    return claimedAt;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    RecipeSerializationClaim that = (RecipeSerializationClaim) o;
+    return id.equals(that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
+}

--- a/karamel-core/src/main/java/se/kth/karamel/backend/running/model/tasks/Task.java
+++ b/karamel-core/src/main/java/se/kth/karamel/backend/running/model/tasks/Task.java
@@ -84,7 +84,11 @@ public abstract class Task implements DagTask, TaskCallback {
   public String getSshUser() {
     return sshUser;
   }
-  
+
+  public DagTaskCallback getDagCallback() {
+    return dagCallback;
+  }
+
   public String getName() {
     return name;
   }

--- a/karamel-core/src/test/java/se/kth/karamel/backend/dag/DagTest.java
+++ b/karamel-core/src/test/java/se/kth/karamel/backend/dag/DagTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Set;
 import org.junit.Assert;
 import org.junit.Test;
+import se.kth.karamel.common.clusterdef.json.JsonCluster;
 import se.kth.karamel.common.exception.DagConstructionException;
 
 /**
@@ -160,7 +161,7 @@ public class DagTest {
     dag.addTask(new DummyTask("task31"));
     dag.addTask(new DummyTask("task32"));
     //task33 doesnt have any task, expecting exception here
-    dag.start();
+    dag.start(new JsonCluster());
   }
 
   @Test
@@ -232,7 +233,7 @@ public class DagTest {
     dag.addTask(new DummyTask("task31"));
     dag.addTask(new DummyTask("task32"));
     dag.addTask(new DummyTask("task33"));
-    dag.start();
+    dag.start(new JsonCluster());
   }
 
   @Test


### PR DESCRIPTION
[CLOUD-570] Make recipes parallelism configurable

[CLOUD-570] Ignore recipe parallelism if less than or equal to zero

[CLOUD-570] Fix deadlock by moving the lock after queuing, right before execution

[CLOUD-570] Log information of lock claims

[CLOUD-570] Documentation

[CLOUD-570]: https://hopsworks.atlassian.net/browse/CLOUD-570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLOUD-570]: https://hopsworks.atlassian.net/browse/CLOUD-570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLOUD-570]: https://hopsworks.atlassian.net/browse/CLOUD-570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLOUD-570]: https://hopsworks.atlassian.net/browse/CLOUD-570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLOUD-570]: https://hopsworks.atlassian.net/browse/CLOUD-570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ