### PR TITLE
[HWORKS-726] Delete nodes directory for airgap environments

### DIFF
--- a/karamel-core/src/main/java/se/kth/karamel/backend/running/model/tasks/VendorCookbookTask.java
+++ b/karamel-core/src/main/java/se/kth/karamel/backend/running/model/tasks/VendorCookbookTask.java
@@ -6,7 +6,6 @@
 package se.kth.karamel.backend.running.model.tasks;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -49,10 +48,7 @@ public class VendorCookbookTask extends Task {
     if (subCookbookName != null && !subCookbookName.isEmpty()) {
       cookbookPath += Settings.SLASH + subCookbookName;
     }
-    if (Boolean.parseBoolean(conf.getProperty(Settings.KARAMEL_AIRGAP))) {
-      commands = new ArrayList<>(0);
-      return commands;
-    }
+    boolean airgap = Boolean.parseBoolean(conf.getProperty(Settings.KARAMEL_AIRGAP));
     if (commands == null) {
       commands = ShellCommandBuilder.makeSingleFileCommand(Settings.SCRIPT_PATH_CLONE_VENDOR_COOKBOOK,
           "cookbooks_home", cookbooksHome,
@@ -65,7 +61,8 @@ public class VendorCookbookTask extends Task {
           "task_id", getId(),
           "install_dir_path", Settings.REMOTE_INSTALL_DIR_PATH(getSshUser()),          
           "succeedtasks_filepath", Settings.SUCCEED_TASKLIST_FILENAME,
-          "pid_file", Settings.PID_FILE_NAME);
+          "pid_file", Settings.PID_FILE_NAME,
+          "is_airgap", String.valueOf(airgap));
     }
     return commands;
   }

--- a/karamel-core/src/main/resources/se/kth/karamel/backend/shellscripts/clone_vendor_cookbook.sb
+++ b/karamel-core/src/main/resources/se/kth/karamel/backend/shellscripts/clone_vendor_cookbook.sb
@@ -1,15 +1,20 @@
 set -e; mkdir -p %install_dir_path% ; cd %install_dir_path%; echo $$ > %pid_file%; echo '#!/bin/bash
 set -e
-export LC_CTYPE=en_US.UTF-8
-# %sudo% chown -R $USER ~/.berkshelf
-mkdir -p %cookbooks_home%
-cd %cookbooks_home%
-%sudo_command% rm -rf nodes
-rm -fr %github_repo_name%*
-git clone %github_repo_url%
-cd %github_repo_name%
-git checkout %branch_name%
-berks vendor %vendor_path%
-cd %install_dir_path%
-echo '%task_id%' >> %succeedtasks_filepath%
+
+IS_AIRGAP=%is_airgap%
+%sudo_command% rm -rf %cookbooks_home%/nodes
+
+if [ "$IS_AIRGAP" == "false" ]; then
+    export LC_CTYPE=en_US.UTF-8
+    # %sudo% chown -R $USER ~/.berkshelf
+    mkdir -p %cookbooks_home%
+    cd %cookbooks_home%
+    rm -fr %github_repo_name%*
+    git clone %github_repo_url%
+    cd %github_repo_name%
+    git checkout %branch_name%
+    berks vendor %vendor_path%
+    cd %install_dir_path%
+    echo '%task_id%' >> %succeedtasks_filepath%
+fi
 ' > clone_%github_repo_name%.sh ; chmod +x clone_%github_repo_name%.sh ; ./clone_%github_repo_name%.sh


### PR DESCRIPTION
Airgap installations will still run the `clone and vendor Hopsworks` but in reality it will only delete the `nodes` directory.